### PR TITLE
Adding allow_pickle = True as an argument to np.load in def load.

### DIFF
--- a/neural_network.py
+++ b/neural_network.py
@@ -72,8 +72,8 @@ class NeuralNetwork:
         :param filename_weights: file containing saved weights
         :param filename_biases: file containing saved biases
         """
-        self.weights = np.load(filename_weights)
-        self.biases = np.load(filename_biases)
+        self.weights = np.load(filename_weights, allow_pickle = True)
+        self.biases = np.load(filename_biases, allow_pickle = True)
 
     def render(self, window, vision):
         """


### PR DESCRIPTION
This will mitigate the ValueError: Object arrays cannot be loaded when allow_pickle=False to pop up.